### PR TITLE
Fix typo of Misasa

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
 == README
 
 Serve as Medusa to keep track specimens and boxes.
-More details can be found on the official website http://dream.miasa.okayama-u.ac.jp
+More details can be found on the official website http://dream.misasa.okayama-u.ac.jp/


### PR DESCRIPTION
The URL for the Medusa main was fixed because it was simply incorrect.  This is just a correction and the pull request should be accepted without evaluation.