### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/app/models/bib.rb
+++ b/app/models/bib.rb
@@ -52,7 +52,7 @@ class Bib < ActiveRecord::Base
 
   def doi_link_url
     return unless doi
-    "http://dx.doi.org/#{doi}"
+    "https://doi.org/#{doi}"
   end
   
   def primary_pdf_attachment_file

--- a/app/models/sesar.rb
+++ b/app/models/sesar.rb
@@ -253,7 +253,7 @@ class Sesar < ActiveResource::Base
     if model.bibs.present?
       model.bibs.each do |bib|
         next if bib.doi.blank?
-        urls.push({url: "http://dx.doi.org/#{bib.doi}", description: bib.name, url_type: "DOI"})
+        urls.push({url: "https://doi.org/#{bib.doi}", description: bib.name, url_type: "DOI"})
       end
     end
     urls

--- a/spec/models/bib_spec.rb
+++ b/spec/models/bib_spec.rb
@@ -55,7 +55,7 @@ describe Bib do
     end
     context "doi is not nil" do
       let(:doi_1) { "test" }
-      it { expect(subject).to eq "http://dx.doi.org/test" }
+      it { expect(subject).to eq "https://doi.org/test" }
     end
   end
   

--- a/spec/models/sesar_spec.rb
+++ b/spec/models/sesar_spec.rb
@@ -104,7 +104,7 @@ describe Sesar do
         it { expect(@xml).to include "<sample_other_names><sample_other_name>#{specimen.global_id}</sample_other_name></sample_other_names>" }
       end
       context "external_urls" do
-        it { expect(@xml).to include "<external_urls><external_url><url>http://dream.misasa.okayama-u.ac.jp/?q=#{specimen.global_id}</url><description/><url_type>regular URL</url_type></external_url><external_url><url>http://dx.doi.org/doi１</url><description>書誌情報１</description><url_type>DOI</url_type></external_url></external_urls>" }
+        it { expect(@xml).to include "<external_urls><external_url><url>http://dream.misasa.okayama-u.ac.jp/?q=#{specimen.global_id}</url><description/><url_type>regular URL</url_type></external_url><external_url><url>https://doi.org/doi１</url><description>書誌情報１</description><url_type>DOI</url_type></external_url></external_urls>" }
       end
     end
 
@@ -203,7 +203,7 @@ describe Sesar do
       context "紐づくbibが存在しない場合" do
         let(:model) { FactoryGirl.create(:specimen, igsn: "") }
         it { expect(subject).to include({description: nil, url_type: "regular URL", url: "http://dream.misasa.okayama-u.ac.jp/?q=#{model.global_id}"}) }
-        it { expect(subject).to_not include({url: "http://dx.doi.org/doi１", description: "書誌情報１", url_type: "DOI"}) }
+        it { expect(subject).to_not include({url: "https://doi.org/doi１", description: "書誌情報１", url_type: "DOI"}) }
       end
       context "紐づくbibが存在する場合" do
         let(:model) { FactoryGirl.create(:specimen, igsn: "") }
@@ -211,15 +211,15 @@ describe Sesar do
         before do
           model.bibs << bib
         end        
-        it { expect(subject).to include({url: "http://dx.doi.org/doi１", description: "書誌情報１", url_type: "DOI"}) }
+        it { expect(subject).to include({url: "https://doi.org/doi１", description: "書誌情報１", url_type: "DOI"}) }
         context "doi is nil" do
           let(:bib) { FactoryGirl.create(:bib, doi: nil)}
-          it { expect(subject).not_to include({url: "http://dx.doi.org/", description: "書誌情報１", url_type: "DOI"}) }
+          it { expect(subject).not_to include({url: "https://doi.org/", description: "書誌情報１", url_type: "DOI"}) }
         end
 
         context "doi is ''" do
           let(:bib) { FactoryGirl.create(:bib, doi: "")}
-          it { expect(subject).not_to include({url: "http://dx.doi.org/", description: "書誌情報１", url_type: "DOI"}) }
+          it { expect(subject).not_to include({url: "https://doi.org/", description: "書誌情報１", url_type: "DOI"}) }
         end
 
       end


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new ones.

I also updated some code that look like tests to me (new to Ruby, sorry). Please let me know if those depend on external service who still provide `http://dx.doi.org/` URLs, and I'll revert those updates.

Cheers!