### PR TITLE
Update sesar sync

### DIFF
--- a/app/models/sesar.rb
+++ b/app/models/sesar.rb
@@ -91,8 +91,8 @@ class Sesar < ActiveResource::Base
     attributes[:age_min] = model.age_min
     attributes[:age_max] = model.age_max
     attributes[:age_unit] = age_unit_conversion(model.age_unit)
-    attributes[:size] = model.size
-    attributes[:size_unit] = model.size_unit
+    attributes[:size] = model.size.present? || model.size_unit.present? ? model.size : model.quantity
+    attributes[:size_unit] = model.size.present? || model.size_unit.present? ? model.size_unit : model.quantity_unit
     attributes[:latitude] = model.place.try!(:latitude)
     attributes[:longitude] = model.place.try!(:longitude)
     attributes[:elevation] = model.place.try!(:elevation)

--- a/app/models/sesar.rb
+++ b/app/models/sesar.rb
@@ -90,7 +90,7 @@ class Sesar < ActiveResource::Base
     attributes[:classification] = array_classification(model.classification)
     attributes[:age_min] = model.age_min
     attributes[:age_max] = model.age_max
-    attributes[:age_unit] = model.age_unit
+    attributes[:age_unit] = age_unit_conversion(model.age_unit)
     attributes[:size] = model.size
     attributes[:size_unit] = model.size_unit
     attributes[:latitude] = model.place.try!(:latitude)
@@ -267,6 +267,19 @@ class Sesar < ActiveResource::Base
       .where.not(value: '')\
       .where.not(custom_attributes: {sesar_name: nil})\
       .where.not(custom_attributes: {sesar_name: ''})
+  end
+
+  def self.age_unit_conversion(age_unit)
+    return "" if age_unit.blank?
+    age_unit_list = YAML.load(File.read("#{Rails.root}/config/age_unit.yml"))
+
+    if age_unit == "a"
+      "years"
+    elsif age_unit_list.has_key?(age_unit)
+      "#{age_unit_list[age_unit]} (#{age_unit})"
+    else
+      age_unit
+    end
   end
 
   private

--- a/app/models/sesar.rb
+++ b/app/models/sesar.rb
@@ -273,10 +273,8 @@ class Sesar < ActiveResource::Base
     return "" if age_unit.blank?
     age_unit_list = YAML.load(File.read("#{Rails.root}/config/age_unit.yml"))
 
-    if age_unit == "a"
-      "years"
-    elsif age_unit_list.has_key?(age_unit)
-      "#{age_unit_list[age_unit]} (#{age_unit})"
+    if age_unit_list.has_key?(age_unit)
+      age_unit == "a" ? age_unit_list[age_unit] : "#{age_unit_list[age_unit]} (#{age_unit})"
     else
       age_unit
     end

--- a/app/views/specimens/detail_edit.html.erb
+++ b/app/views/specimens/detail_edit.html.erb
@@ -37,11 +37,11 @@
   </div>
   <div class="form-group form-group-sm">
     <%= f.label :collected_at, class: "small" %>
-    <%= f.text_field :collected_at, class: "form-control input-sm", placeholder: "yyyy-mm-dd hh:mm:ss" %>
+    <%= f.datetime_local_field :collected_at, class: "form-control input-sm", placeholder: "yyyy-mm-dd hh:mm:ss" %>
   </div>
   <div class="form-group form-group-sm">
     <%= f.label :collected_end_at, class: "small" %>
-    <%= f.text_field :collected_end_at, class: "form-control input-sm", placeholder: "yyyy-mm-dd hh:mm:ss" %>
+    <%= f.datetime_local_field :collected_end_at, class: "form-control input-sm", placeholder: "yyyy-mm-dd hh:mm:ss" %>
   </div>
   <div class="form-group form-group-sm">
     <%= f.label :collection_date_precision, class: "small" %>

--- a/spec/models/sesar_spec.rb
+++ b/spec/models/sesar_spec.rb
@@ -115,6 +115,28 @@ describe Sesar do
     context "place is not blank" do
       it { expect(subject.attributes.has_key?(:country_id)).to eq false }
     end
+    context "size and size_unit are blank" do
+      before do
+        specimen.size = nil
+        specimen.size_unit = nil
+      end
+      it { expect(subject.attributes[:size]).to eq specimen.quantity }
+      it { expect(subject.attributes[:size_unit]).to eq specimen.quantity_unit }
+    end
+    context "only size is blank" do
+      before do
+        specimen.size = nil
+      end
+      it { expect(subject.attributes[:size]).to eq specimen.size }
+      it { expect(subject.attributes[:size_unit]).to eq specimen.size_unit }
+    end
+    context "only size_unit is blank" do
+      before do
+        specimen.size_unit = nil
+      end
+      it { expect(subject.attributes[:size]).to eq specimen.size }
+      it { expect(subject.attributes[:size_unit]).to eq specimen.size_unit }
+    end
 
     describe "to_xml" do
       before do

--- a/spec/models/sesar_spec.rb
+++ b/spec/models/sesar_spec.rb
@@ -69,7 +69,7 @@ describe Sesar do
       expect(sesar.attributes["igsn"]).to eq specimen.igsn
       expect(sesar.attributes["age_min"]).to eq specimen.age_min
       expect(sesar.attributes["age_max"]).to eq specimen.age_max
-      expect(sesar.attributes["age_unit"]).to eq specimen.age_unit
+      expect(sesar.attributes["age_unit"]).to eq "years"
       expect(sesar.attributes["size"]).to eq specimen.size
       expect(sesar.attributes["size_unit"]).to eq specimen.size_unit
       expect(sesar.attributes["latitude"]).to eq specimen.place.latitude
@@ -439,6 +439,26 @@ describe Sesar do
     context "specimenレコードのigsn属性が空" do
       let(:igsn) { "" }
       it { expect(subject).to eq false }
+    end
+  end
+
+  describe ".age_unit_conversion" do
+    subject { Sesar.age_unit_conversion(age_unit) }
+    context "age_unitがblank" do
+      let(:age_unit) { nil }
+      it { expect(subject).to eq "" }
+    end
+    context "age_unitが'a'" do
+      let(:age_unit) { "a" }
+      it { expect(subject).to eq "years" }
+    end
+    context "age_unitが'a'以外かつ設定ファイルに定義されている" do
+      let(:age_unit) { "Ma" }
+      it { expect(subject).to eq "million years (Ma)" }
+    end
+    context "age_unitが設定ファイルに定義されていない" do
+      let(:age_unit) { "other" }
+      it { expect(subject).to eq "other" }
     end
   end
 


### PR DESCRIPTION
SESARとの同期処理について、以下の変更を行いました。
レビューをお願いいたします。

■変更点
・collected_at, collected_end_atのフォームコントロールを修正
　※Specimen詳細画面で更新するたびに-9時間ずれるため、
　　画面に正しく(JSTで)表示されるようフォームコントロールを変更。

・Sesar upload時のage_unitの変換処理を追加
　※DBの値のままではSESARに正しく登録されないため、
　　"a"の場合は"years"、"Ma"の場合は"million years (Ma)"のように変換して送信するよう変更。

・sizeとsize_unitが空の場合、quantityとquantity_unitの値をSESARに登録するよう変更