### PR TITLE
access with post method

### DIFF
--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -70,7 +70,7 @@
       	<% if @user.omniauth_uid(:shibboleth).present? %>
       	  <%= link_to("Unlink", unlink_account_path(provider: :shibboleth), method: :post, class: "btn btn-mini btn-default") %>
       	<% else %>
-      	  <%= link_to "Link", user_shibboleth_omniauth_authorize_url(protocol: "https://"), class: "btn btn-mini btn-default" %>
+      	  <%= link_to "Link", user_shibboleth_omniauth_authorize_url(protocol: "https://"), class: "btn btn-mini btn-default", method: :post %>
       	<% end %>
       </div>
     <% end %>


### PR DESCRIPTION
アカウント編集ページにおいて、okayama-u ID Link をクリックすると、"Not found. Authentication passthru" のページが表示され進行しませんでした。そこでクリックした際に post method で送信するように修正しました。